### PR TITLE
replicate phpstan 12585

### DIFF
--- a/tests/Integration/data/model-builder.php
+++ b/tests/Integration/data/model-builder.php
@@ -3,10 +3,13 @@
 namespace ModelBuilder;
 
 use App\Post;
+use App\PostBuilder;
 use App\Team;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
+
+use function PHPStan\Testing\assertType;
 
 class User extends Model
 {
@@ -39,4 +42,19 @@ function test(): void
 
     /** @see https://github.com/larastan/larastan/issues/1952 */
     Team::query()->where('name', 'Team A')->orderBy('name')->get();
+
+    \App\User::query()->whereHas('posts', function ($query) {
+        assertType('App\PostBuilder<App\Post>', $query);
+        return $query->where('name', 'like', 'Foo%');
+    })->get();
+
+    \App\User::query()->whereHas('posts', function (Builder $query) {
+        assertType('App\PostBuilder<App\Post>', $query);
+        return $query->where('name', 'like', 'Foo%');
+    })->get();
+
+    \App\User::query()->whereHas('posts', function (PostBuilder $query) {
+        assertType('App\PostBuilder<App\Post>', $query);
+        return $query->where('name', 'like', 'Foo%');
+    })->get();
 }


### PR DESCRIPTION
Replicates the bug in https://github.com/phpstan/phpstan/issues/12585

The test fails with:

```
- Anonymous function should return Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model> but returns App\PostBuilder<App\Post>
- Anonymous function should return Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model> but returns App\PostBuilder<App\Post>
- Parameter #2 $callback of method Illuminate\Database\Eloquent\Builder<App\User>::whereHas() expects
  (Closure(Illuminate\Database\Eloquent\Builder<App\Post>): mixed)|null,
  Closure(App\PostBuilder): void given
```