### PR TITLE
Revert "fix: allow private methods to be used as accessors"

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ This fork is intended to provide the community with immediate access to these en
 
 This fork includes the following changes and enhancements:
 
-- [fix: allow private methods to be used as accessors](https://github.com/larastan/larastan/pull/2334)
 - [feat: add optional noModelForwardingToBuilder and noModelStaticForwardingToBuilder](https://github.com/larastan/larastan/pull/2317)
 - [fix: chunkWhile generics](https://github.com/larastan/larastan/pull/2262)
 - [fix: factory {has,for}* methods should return static](https://github.com/larastan/larastan/pull/2252)

--- a/src/Properties/ModelPropertyHelper.php
+++ b/src/Properties/ModelPropertyHelper.php
@@ -139,7 +139,7 @@ class ModelPropertyHelper
 
         $methodReflection = $classReflection->getNativeMethod($camelCase);
 
-        if ($methodReflection->isPublic()) {
+        if ($methodReflection->isPublic() || $methodReflection->isPrivate()) {
             return false;
         }
 


### PR DESCRIPTION
Reverts calebdw/larastan#43

See upstream, accessors cannot be private even in final classes