### PR TITLE
fix: mark macro methods as static only if the closure is static

### DIFF
--- a/src/Methods/Macro.php
+++ b/src/Methods/Macro.php
@@ -20,11 +20,6 @@ use function array_key_exists;
 final class Macro implements MethodReflection
 {
     /**
-     * The is static.
-     */
-    private bool $isStatic = false;
-
-    /**
      * Map of macro methods and thrown exception classes.
      *
      * @var string[]
@@ -34,7 +29,7 @@ final class Macro implements MethodReflection
         'validateWithBag' => ValidationException::class,
     ];
 
-    public function __construct(private ClassReflection $classReflection, private string $methodName, private ClosureType $closureType)
+    public function __construct(private ClassReflection $classReflection, private string $methodName, private ClosureType $closureType, private bool $isStatic = false)
     {
     }
 
@@ -66,14 +61,6 @@ final class Macro implements MethodReflection
     public function isStatic(): bool
     {
         return $this->isStatic;
-    }
-
-    /**
-     * Set the is static value.
-     */
-    public function setIsStatic(bool $isStatic): void
-    {
-        $this->isStatic = $isStatic;
     }
 
     public function getDocComment(): string|null

--- a/src/Methods/MacroMethodsClassReflectionExtension.php
+++ b/src/Methods/MacroMethodsClassReflectionExtension.php
@@ -25,6 +25,7 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ClosureTypeFactory;
 use ReflectionException;
+use ReflectionFunction;
 use Throwable;
 
 use function array_key_exists;
@@ -167,9 +168,9 @@ class MacroMethodsClassReflectionExtension implements MethodsClassReflectionExte
                         $macroClassReflection,
                         $methodName,
                         $this->closureTypeFactory->fromClosureObject($macroDefinition),
+                        /** @phpstan-ignore phpstanApi.runtimeReflection */
+                        (new ReflectionFunction($macroDefinition))->isStatic(),
                     );
-
-                    $methodReflection->setIsStatic(true);
                 }
 
                 $this->methods[$classReflection->getName() . '-' . $methodName] = $methodReflection;


### PR DESCRIPTION
Upstream PR: https://github.com/larastan/larastan/pull/2398
